### PR TITLE
Dust templates can be updated without restart.

### DIFF
--- a/lib/onLoad.js
+++ b/lib/onLoad.js
@@ -43,7 +43,8 @@ module.exports = function(config) {
                             if (err) {
                                 return callback(err);
                             }
-
+                            
+                            delete require.cache[compiledOutputFilename];
                             dust.cache[input] = require(compiledOutputFilename);
                             callback();
                         });


### PR DESCRIPTION
Updates to dust templates with dust caching turned off does not reflect without server restart since require() caches the compiled module even when the compiled source changes.
